### PR TITLE
Use std bean naming for getters

### DIFF
--- a/src/main/java/org/creek/api/platform/metadata/ComponentDescriptor.java
+++ b/src/main/java/org/creek/api/platform/metadata/ComponentDescriptor.java
@@ -24,20 +24,20 @@ import java.util.List;
 public interface ComponentDescriptor {
 
     /** @return the unique name of the component within the platform */
-    String name();
+    String getName();
 
     /** @return the inputs to the component, e.g. Kafka topics it consumes. */
-    default Collection<ComponentInput> inputs() {
+    default Collection<ComponentInput> getInputs() {
         return List.of();
     }
 
     /** @return the internals to the component, e.g. changelog or repartition Kafka topics. */
-    default Collection<ComponentInternal> internals() {
+    default Collection<ComponentInternal> getInternals() {
         return List.of();
     }
 
     /** @return the outputs from the component, e.g. the Kafka topics it outputs too */
-    default Collection<ComponentOutput> outputs() {
+    default Collection<ComponentOutput> getOutputs() {
         return List.of();
     }
 }

--- a/src/main/java/org/creek/api/platform/metadata/ServiceDescriptor.java
+++ b/src/main/java/org/creek/api/platform/metadata/ServiceDescriptor.java
@@ -30,15 +30,15 @@ public interface ServiceDescriptor extends ComponentDescriptor {
      *
      * @return the service's docker image name.
      */
-    default String dockerImage() {
-        return name();
+    default String getDockerImage() {
+        return getName();
     }
 
     /**
      * Allows customisation of the environment variables available to the service during system
      * testing.
      */
-    default Map<String, String> testEnvironment() {
+    default Map<String, String> getTestEnvironment() {
         return Map.of();
     }
 }

--- a/src/test/java/org/creek/api/platform/metadata/ComponentDescriptorTest.java
+++ b/src/test/java/org/creek/api/platform/metadata/ComponentDescriptorTest.java
@@ -28,8 +28,8 @@ class ComponentDescriptorTest {
 
     @Test
     void shouldDefaultToEmptyResources() {
-        assertThat(descriptor.inputs(), is(empty()));
-        assertThat(descriptor.internals(), is(empty()));
-        assertThat(descriptor.outputs(), is(empty()));
+        assertThat(descriptor.getInputs(), is(empty()));
+        assertThat(descriptor.getInternals(), is(empty()));
+        assertThat(descriptor.getOutputs(), is(empty()));
     }
 }

--- a/src/test/java/org/creek/api/platform/metadata/ServiceDescriptorTest.java
+++ b/src/test/java/org/creek/api/platform/metadata/ServiceDescriptorTest.java
@@ -28,11 +28,11 @@ class ServiceDescriptorTest {
 
     @Test
     void shouldDefaultImageNameToServiceName() {
-        assertThat(descriptor.dockerImage(), is(descriptor.name()));
+        assertThat(descriptor.getDockerImage(), is(descriptor.getName()));
     }
 
     @Test
     void shouldDefaultToNoTestEnv() {
-        assertThat(descriptor.testEnvironment().entrySet(), is(empty()));
+        assertThat(descriptor.getTestEnvironment().entrySet(), is(empty()));
     }
 }


### PR DESCRIPTION
...as this should make JSON serialization easier later, as `getXXX()` style getters are auto-included by libraries like Jackson.
