### PR TITLE
Require docker image name

### DIFF
--- a/src/main/java/org/creekservice/api/platform/metadata/ServiceDescriptor.java
+++ b/src/main/java/org/creekservice/api/platform/metadata/ServiceDescriptor.java
@@ -29,16 +29,14 @@ public interface ServiceDescriptor extends ComponentDescriptor {
     }
 
     /**
-     * The simple name of the docker image that contains the service.
+     * The name of the docker image that contains the service, without version info.
      *
-     * <p>Given a full image name of {@code confluentinc/cp-kafka:6.1.2}, this method should return
-     * {@code cp-kafka}.
+     * <p>For example, given a full image name of {@code confluentinc/cp-kafka:6.1.2}, this method
+     * should return {@code confluentinc/cp-kafka}.
      *
      * @return the service's docker image name.
      */
-    default String dockerImage() {
-        return name();
-    }
+    String dockerImage();
 
     /**
      * Allows customisation of the environment variables available to the service during system

--- a/src/test/java/org/creekservice/api/platform/metadata/ServiceDescriptorTest.java
+++ b/src/test/java/org/creekservice/api/platform/metadata/ServiceDescriptorTest.java
@@ -47,6 +47,7 @@ class ServiceDescriptorTest {
                 is("Non-standard class name: either override getName or use standard naming"));
     }
 
+    @Test
     void shouldDefaultToNoTestEnv() {
         assertThat(descriptor.testEnvironment().entrySet(), is(empty()));
     }

--- a/src/test/java/org/creekservice/api/platform/metadata/ServiceDescriptorTest.java
+++ b/src/test/java/org/creekservice/api/platform/metadata/ServiceDescriptorTest.java
@@ -47,19 +47,23 @@ class ServiceDescriptorTest {
                 is("Non-standard class name: either override getName or use standard naming"));
     }
 
-    @Test
-    void shouldDefaultImageNameToServiceName() {
-        assertThat(descriptor.dockerImage(), is(descriptor.name()));
-    }
-
-    @Test
     void shouldDefaultToNoTestEnv() {
         assertThat(descriptor.testEnvironment().entrySet(), is(empty()));
     }
 
-    private static final class TestServiceDescriptor implements ServiceDescriptor {}
+    private static final class TestServiceDescriptor implements ServiceDescriptor {
+        @Override
+        public String dockerImage() {
+            return null;
+        }
+    }
 
     private static final class SupportedDescriptor implements AggregateDescriptor {}
 
-    private static final class NonStandard implements ServiceDescriptor {}
+    private static final class NonStandard implements ServiceDescriptor {
+        @Override
+        public String dockerImage() {
+            return null;
+        }
+    }
 }


### PR DESCRIPTION
Previously, the docker image name defaulted to the service name.  This isn't a useful default, as each company will prefix their image names with their own company name or similar.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended