### PR TITLE
Add component discovery

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,3 +1,5 @@
 module creek.platform.metadata {
     exports org.creekservice.api.platform.metadata;
+
+    uses org.creekservice.api.platform.metadata.ComponentDescriptor;
 }

--- a/src/main/java/org/creekservice/api/platform/metadata/ComponentDescriptors.java
+++ b/src/main/java/org/creekservice/api/platform/metadata/ComponentDescriptors.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.api.platform.metadata;
+
+
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.stream.Collectors;
+
+public final class ComponentDescriptors {
+
+    private ComponentDescriptors() {}
+
+    /** Instantiate any extensions available at runtime. */
+    public static List<ComponentDescriptor> load() {
+        return ServiceLoader.load(ComponentDescriptor.class).stream()
+                .map(ServiceLoader.Provider::get)
+                .collect(Collectors.toUnmodifiableList());
+    }
+}

--- a/src/main/java/org/creekservice/api/platform/metadata/ServiceDescriptor.java
+++ b/src/main/java/org/creekservice/api/platform/metadata/ServiceDescriptor.java
@@ -25,7 +25,7 @@ public interface ServiceDescriptor extends ComponentDescriptor {
 
     @Override
     default String name() {
-        return defaultNaming(this, "ServiceDescriptor", "Descriptor");
+        return defaultNaming(this, "Descriptor");
     }
 
     /**

--- a/src/main/java/org/creekservice/internal/platform/metadata/Components.java
+++ b/src/main/java/org/creekservice/internal/platform/metadata/Components.java
@@ -18,7 +18,6 @@ package org.creekservice.internal.platform.metadata;
 
 
 import java.util.Arrays;
-import java.util.Locale;
 import org.creekservice.api.platform.metadata.ComponentDescriptor;
 
 public final class Components {
@@ -31,12 +30,18 @@ public final class Components {
         final String found =
                 Arrays.stream(supportedPostFixes)
                         .filter(className::endsWith)
-                        .findAny()
+                        .findFirst()
                         .orElseThrow(
                                 () ->
                                         new UnsupportedOperationException(
-                                                "Non-standard class name: either override getName or use standard naming"));
+                                                "Non-standard class name: either override name() or use standard naming"));
 
-        return className.substring(0, className.length() - found.length()).toLowerCase(Locale.ROOT);
+        final String name =
+                className
+                        .substring(0, className.length() - found.length())
+                        .replaceAll("([A-Z])", "-$1")
+                        .toLowerCase();
+
+        return name.indexOf("-") == 0 ? name.substring(1) : name;
     }
 }

--- a/src/test/java/org/creekservice/api/platform/metadata/AggregateDescriptorTest.java
+++ b/src/test/java/org/creekservice/api/platform/metadata/AggregateDescriptorTest.java
@@ -41,7 +41,7 @@ class AggregateDescriptorTest {
         // Then:
         assertThat(
                 e.getMessage(),
-                is("Non-standard class name: either override getName or use standard naming"));
+                is("Non-standard class name: either override name() or use standard naming"));
     }
 
     private static final class StandardAggregateDescriptor implements AggregateDescriptor {}

--- a/src/test/java/org/creekservice/api/platform/metadata/ComponentDescriptorsTest.java
+++ b/src/test/java/org/creekservice/api/platform/metadata/ComponentDescriptorsTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.api.platform.metadata;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ComponentDescriptorsTest {
+
+    @Test
+    void shouldLoadTestDescriptors() {
+        // When:
+        final List<ComponentDescriptor> result = ComponentDescriptors.load();
+
+        // Then:
+        assertThat(result, is(empty()));
+    }
+}

--- a/src/test/java/org/creekservice/api/platform/metadata/ServiceDescriptorTest.java
+++ b/src/test/java/org/creekservice/api/platform/metadata/ServiceDescriptorTest.java
@@ -29,8 +29,7 @@ class ServiceDescriptorTest {
 
     @Test
     void shouldReturnStandardAggregateName() {
-        assertThat(new TestServiceDescriptor().name(), is("test"));
-        assertThat(new SupportedDescriptor().name(), is("supported"));
+        assertThat(new TestServiceDescriptor().name(), is("test-service"));
     }
 
     @Test
@@ -44,7 +43,7 @@ class ServiceDescriptorTest {
         // Then:
         assertThat(
                 e.getMessage(),
-                is("Non-standard class name: either override getName or use standard naming"));
+                is("Non-standard class name: either override name() or use standard naming"));
     }
 
     @Test
@@ -58,8 +57,6 @@ class ServiceDescriptorTest {
             return null;
         }
     }
-
-    private static final class SupportedDescriptor implements AggregateDescriptor {}
 
     private static final class NonStandard implements ServiceDescriptor {
         @Override

--- a/src/test/java/org/creekservice/internal/platform/metadata/ComponentsTest.java
+++ b/src/test/java/org/creekservice/internal/platform/metadata/ComponentsTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 Creek Contributors (https://github.com/creek-service)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.creekservice.internal.platform.metadata;
+
+import static org.creekservice.internal.platform.metadata.Components.defaultNaming;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.creekservice.api.platform.metadata.ComponentDescriptor;
+import org.junit.jupiter.api.Test;
+
+class ComponentsTest {
+
+    @Test
+    void shouldCreateDefaultName() {
+        assertThat(defaultNaming(new TestServiceDescriptor(), "Descriptor"), is("test-service"));
+    }
+
+    @Test
+    void shouldHandleFirstCharNoCapital() {
+        assertThat(
+                defaultNaming(new lowerCaseServiceDescriptor(), "ServiceDescriptor"),
+                is("lower-case"));
+    }
+
+    @Test
+    void shouldReportFirstMatchedPostfix() {
+        assertThat(
+                defaultNaming(new TestServiceDescriptor(), "ServiceDescriptor", "Descriptor"),
+                is("test"));
+    }
+
+    @Test
+    void shouldSupportNamesWithoutAnyMatchingPostfix() {}
+
+    private static final class TestServiceDescriptor implements ComponentDescriptor {
+        @Override
+        public String name() {
+            return null;
+        }
+    }
+
+    @SuppressWarnings("checkstyle:TypeName")
+    private static final class lowerCaseServiceDescriptor implements ComponentDescriptor {
+        @Override
+        public String name() {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Move component discovery from creek-service repo into here as its such a simple bit of code.

Also, fix default naming to give us nicer names, i.e. `TestServiceDescriptor` becomes `test-service` rather than just `test`, and `MyFirstServiceDescriptor` becomes `my-first-service` rather than `myfirst`.

### Reviewer checklist
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended